### PR TITLE
add scocket.io-client and it's type info

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/express": "^4.17.2",
     "@types/node": "^13.7.6",
     "@types/socket.io": "^2.1.4",
+    "@types/socket.io-client": "^1.4.32",
     "@types/uuid": "^7.0.0",
     "body-parser": "^1.19.0",
     "bufferutil": "^4.0.1",
@@ -28,9 +29,11 @@
     "express": "^4.17.1",
     "rxjs": "^6.5.4",
     "socket.io": "^2.3.0",
+    "socket.io-client": "^2.3.0",
     "syncsocketio": "^1.0.1",
     "typescript": "^3.8.2",
     "utf-8-validate": "^5.0.2",
     "uuid": "^7.0.1"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
I cannot build for missing socket.io client and it's type info.
Therefore, I append these to package.config.

Thanks,